### PR TITLE
Desired accuracy and logging

### DIFF
--- a/Classes/AKLocationManager.h
+++ b/Classes/AKLocationManager.h
@@ -54,6 +54,14 @@ typedef enum {
 //
 + (void)setDistanceFilterAccuracy:(CLLocationAccuracy)accuracy;
 
+// 
+// Desired accuracy
+//
+// CLLocationAccuracy used to represent a location accuracy level in meters. The lower the value in meters, the
+// more physically precise the location is. A negative accuracy value indicates an invalid location.
+// 
++ (void)setDesiredAccuracy:(CLLocationAccuracy)desiredAccuracy;
+
 //
 // Number of seconds to wait before timing out - default is 10
 //

--- a/Classes/AKLocationManager.h
+++ b/Classes/AKLocationManager.h
@@ -59,6 +59,8 @@ typedef enum {
 //
 // CLLocationAccuracy used to represent a location accuracy level in meters. The lower the value in meters, the
 // more physically precise the location is. A negative accuracy value indicates an invalid location.
+//
+// The default value of this property is 3000.0.
 // 
 + (void)setDesiredAccuracy:(CLLocationAccuracy)desiredAccuracy;
 

--- a/Classes/AKLocationManager.m
+++ b/Classes/AKLocationManager.m
@@ -34,6 +34,7 @@ static AKLocationManager *_locationManager = nil;
 static NSTimer *_locationTimeoutTimer = nil;
 static CLLocationAccuracy _distanceFilterAccuracy = 2000.0f;
 static NSTimeInterval _timeoutTimeInterval = 10.0f;
+static CLLocationAccuracy _desiredAccuracy = 3000.0;
 
 NSString *const kAKLocationManagerErrorDomain = @"AKErrorDomain";
 
@@ -54,6 +55,11 @@ NSString *const kAKLocationManagerErrorDomain = @"AKErrorDomain";
     _distanceFilterAccuracy = accuracy;
 }
 
++ (void)setDesiredAccuracy:(CLLocationAccuracy)desiredAccuracy
+{
+    _desiredAccuracy = desiredAccuracy;
+}
+
 + (void)setTimeoutTimeInterval:(NSTimeInterval)timeInterval
 {
     _timeoutTimeInterval = timeInterval;
@@ -71,7 +77,7 @@ NSString *const kAKLocationManagerErrorDomain = @"AKErrorDomain";
     }
     
     _locationManager.distanceFilter = _distanceFilterAccuracy;
-    _locationManager.desiredAccuracy = kCLLocationAccuracyThreeKilometers;
+    _locationManager.desiredAccuracy = _desiredAccuracy;
     _locationManager.delegate = _locationManager;
     
     _locationTimeoutTimer = [NSTimer scheduledTimerWithTimeInterval:_timeoutTimeInterval

--- a/Classes/AKLocationManager.m
+++ b/Classes/AKLocationManager.m
@@ -41,9 +41,13 @@ NSString *const kAKLocationManagerErrorDomain = @"AKErrorDomain";
 //
 // If you need logging, just uncomment the line below and comment AKLLog(...) inside #ifdef DEBUG
 //
+// If you want to disable logging completely, add #define AKLLog(...) to your prefix file
+//
+
 #ifdef DEBUG
-//#   define AKLLog(...)
-#   define AKLLog(fmt, ...) NSLog((@"AKLocation - [Line %d] " fmt), __LINE__, ##__VA_ARGS__);
+#   ifndef AKLLog
+#      define AKLLog(fmt, ...) NSLog((@"AKLocation - [Line %d] " fmt), __LINE__, ##__VA_ARGS__);
+#   endif
 #else
 #   define AKLLog(...)
 #endif


### PR DESCRIPTION
Hi,

I added [check against redefining AKLLog value](https://github.com/romaonthego/AKLocationManager/commit/496cd3141d545db11836f49fba53854339f432de) (it's useful if you don't want to receive AKLLog messages in console, so you can disable it in Prefix.pch file) and ability to [set desiredAccuracy value](https://github.com/romaonthego/AKLocationManager/commit/1dbf960f689516cd51c504c3a5a3c93f7ce04cef).

Please merge and update the podspec in main CocoaPods repo.

Thank you!
