### PR TITLE
Allow undetermined status to allow ask user for authorization

### DIFF
--- a/Classes/AKLocationManager.m
+++ b/Classes/AKLocationManager.m
@@ -165,8 +165,8 @@ NSString *const kAKLocationManagerErrorDomain = @"AKLocationManagerErrorDomain";
 
 + (BOOL)canLocate
 {
-    return ([CLLocationManager authorizationStatus] == kCLAuthorizationStatusAuthorized) &&
-            [CLLocationManager locationServicesEnabled];
+    return ([CLLocationManager authorizationStatus] == kCLAuthorizationStatusAuthorized || [CLLocationManager authorizationStatus] == kCLAuthorizationStatusNotDetermined)
+            && [CLLocationManager locationServicesEnabled];
 }
 
 + (CLLocationCoordinate2D)mostRecentCoordinate


### PR DESCRIPTION
It is imposible to make start locating user until he grants access to his location. Thus we should treat initial state as true.

Waiting for your comments.

Ivan
